### PR TITLE
feat(policy-aws-lambda): extract the lambda response in context

### DIFF
--- a/src/main/java/io/gravitee/policy/aws/lambda/configuration/AwsLambdaPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/aws/lambda/configuration/AwsLambdaPolicyConfiguration.java
@@ -17,6 +17,9 @@ package io.gravitee.policy.aws.lambda.configuration;
 
 import io.gravitee.policy.api.PolicyConfiguration;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
@@ -32,6 +35,8 @@ public class AwsLambdaPolicyConfiguration implements PolicyConfiguration {
     private String function;
 
     private String payload;
+
+    private List<Variable> variables = new ArrayList<>();
 
     private boolean sendToConsumer;
 
@@ -81,6 +86,14 @@ public class AwsLambdaPolicyConfiguration implements PolicyConfiguration {
 
     public void setFunction(String function) {
         this.function = function;
+    }
+
+    public List<Variable> getVariables() {
+        return variables;
+    }
+
+    public void setVariables(List<Variable> variables) {
+        this.variables = variables;
     }
 
     public boolean isSendToConsumer() {

--- a/src/main/java/io/gravitee/policy/aws/lambda/configuration/Variable.java
+++ b/src/main/java/io/gravitee/policy/aws/lambda/configuration/Variable.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.aws.lambda.configuration;
+
+import java.util.Objects;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class Variable {
+
+    private String name;
+
+    private String value;
+
+    public Variable() {}
+
+    public Variable(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Variable that = (Variable) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+}

--- a/src/main/java/io/gravitee/policy/aws/lambda/el/LambdaResponse.java
+++ b/src/main/java/io/gravitee/policy/aws/lambda/el/LambdaResponse.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.aws.lambda.el;
+
+import com.amazonaws.services.lambda.model.InvokeResult;
+import io.gravitee.common.http.HttpHeaders;
+import io.vertx.core.http.HttpClientResponse;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class LambdaResponse {
+
+    private final InvokeResult result;
+    private final String content;
+
+    public LambdaResponse(final InvokeResult result) {
+        this.result = result;
+        this.content = new String(result.getPayload().array());
+    }
+
+    public int getStatus() {
+        return result.getStatusCode();
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -44,6 +44,30 @@
         }
       }
     },
+    "variables" : {
+      "type" : "array",
+      "title": "Context variables",
+      "items" : {
+        "type" : "object",
+        "id" : "urn:jsonschema:io:gravitee:policy:aws:lambda:configuration:Variable",
+        "title": "Variable",
+        "properties" : {
+          "name" : {
+            "title": "Name",
+            "type" : "string"
+          },
+          "value" : {
+            "title": "Value",
+            "type" : "string",
+            "default": "{#jsonPath(#lambdaResponse.content, '$.field')}"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ]
+    },
     "sendToConsumer": {
       "title": "Send lambda function result to consumer",
       "description": "Check this option if you want to send the response of the lambda to the initial consumer without going to the final upstream (endpoints) selected by the gateway.",


### PR DESCRIPTION
* Add the possibility to declare context variables in the policy form.
* Compute and add these variables in context only if calling lambda is a success

Closes gravitee-io/issues#4395