### PR TITLE
test: add integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,13 +35,15 @@
     </parent>
 
     <properties>
-        <gravitee-bom.version>1.0</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
+        <gravitee-bom.version>2.9</gravitee-bom.version>
+        <gravitee-apim.version>3.20.2</gravitee-apim.version>
+        <gravitee-gateway-api.version>2.0.1</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.25.0</gravitee-common.version>
+        <gravitee-common.version>2.1.0</gravitee-common.version>
         <aws-java-sdk-lambda.version>1.11.858</aws-java-sdk-lambda.version>
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
@@ -116,14 +118,9 @@
 
         <!-- Test scope -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
+            <version>${gravitee-apim.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -189,6 +186,46 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>none</exclude>
+                            </excludes>
+                            <includes>
+                                <include>**/*IntegrationTest</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>none</exclude>
+                            </excludes>
+                            <includes>
+                                <include>**/*IntegrationTest</include>
+                            </includes>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicy.java
+++ b/src/main/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicy.java
@@ -56,7 +56,7 @@ public class AwsLambdaPolicy {
     private static final String AWS_LAMBDA_INVALID_RESPONSE = "AWS_LAMBDA_INVALID_RESPONSE";
     private static final String LAMBDA_RESULT_ATTR = "LAMBDA_RESULT";
 
-    private final AwsLambdaPolicyConfiguration configuration;
+    protected final AwsLambdaPolicyConfiguration configuration;
 
     private final AWSLambdaAsync lambdaClient;
 
@@ -312,7 +312,7 @@ public class AwsLambdaPolicy {
         );
     }
 
-    private AWSLambdaAsync initLambdaClient() {
+    protected AWSLambdaAsync initLambdaClient() {
         // initialize the lambda client
         AWSLambdaAsyncClientBuilder clientBuilder;
         BasicAWSCredentials credentials = null;

--- a/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyIntegrationTest.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.aws.lambda;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@GatewayTest
+@DeployApi(
+    {
+        "/apis/aws-lambda-on-request.json",
+        "/apis/aws-lambda-on-request-content.json",
+        "/apis/aws-lambda-on-response.json",
+        "/apis/aws-lambda-on-response-content.json",
+        "/apis/aws-lambda-with-send-to-consumer.json",
+    }
+)
+public class AwsLambdaPolicyIntegrationTest extends AbstractGatewayTest {
+
+    private WireMockServer awsLambdaMock;
+
+    public AwsLambdaPolicyIntegrationTest() {
+        awsLambdaMock = new WireMockServer(wireMockConfig().dynamicPort());
+        awsLambdaMock.start();
+    }
+
+    @AfterAll
+    public void tearDown() {
+        if (null != awsLambdaMock) {
+            awsLambdaMock.stop();
+        }
+    }
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        policies.put("copy-aws-lambda-attribute", PolicyBuilder.build("copy-aws-lambda-attribute", CopyAwsLambdaAttributePolicy.class));
+        policies.put(
+            "aws-lambda-test-policy",
+            PolicyBuilder.build("aws-lambda-test-policy", AwsLambdaTestPolicy.class, AwsLambdaTestPolicyConfiguration.class)
+        );
+    }
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+        super.configureGateway(gatewayConfigurationBuilder);
+        gatewayConfigurationBuilder.set("api.jupiterMode.enabled", "true");
+    }
+
+    @Override
+    public void configureApi(ReactableApi<?> api, Class<?> apiDefinitionClass) {
+        if (apiDefinitionClass.isAssignableFrom(Api.class)) {
+            ((Api) api.getDefinition()).setExecutionMode(ExecutionMode.JUPITER);
+            ((Api) api.getDefinition()).getFlows()
+                .forEach(flow -> {
+                    flow
+                        .getPre()
+                        .stream()
+                        .filter(policy -> "aws-lambda-test-policy".equals(policy.getPolicy()))
+                        .findFirst()
+                        .ifPresent(policy -> {
+                            policy.setConfiguration(policy.getConfiguration().replace("http://localhost:9999", awsLambdaMock.baseUrl()));
+                        });
+
+                    flow
+                        .getPost()
+                        .stream()
+                        .filter(policy -> "aws-lambda-test-policy".equals(policy.getPolicy()))
+                        .findFirst()
+                        .ifPresent(policy -> {
+                            policy.setConfiguration(policy.getConfiguration().replace("http://localhost:9999", awsLambdaMock.baseUrl()));
+                        });
+                });
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("providePath")
+    @DisplayName("Should use AWS Lambda policy and return error from AWS")
+    void shouldUseAwsLambdaPolicyAndReturnError(String path, int endpointCallCount, HttpClient client) throws Exception {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("response from backend")));
+        awsLambdaMock.stubFor(post(anyUrl()).willReturn(forbidden()));
+
+        client
+            .rxRequest(HttpMethod.GET, path)
+            .flatMap(HttpClientRequest::rxSend)
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(500);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(error -> {
+                assertThat(error.toString()).contains("An error occurs while invoking lambda function.");
+                assertThat(error.toString()).contains("Status Code: 403");
+                return true;
+            });
+
+        wiremock.verify(exactly(endpointCallCount), getRequestedFor(urlPathEqualTo("/endpoint")));
+        awsLambdaMock.verify(postRequestedFor(urlMatching("/\\d{4}-\\d{2}-\\d{2}/functions/lambda-example/invocations")));
+    }
+
+    /**
+     * TODO: Here we skip the "/request-content" because the test is not stable and fails randomly.
+     */
+    @ParameterizedTest
+    @MethodSource("providePathAndResponse")
+    @DisplayName("Should use AWS Lambda policy and set response as attribute")
+    void shouldUseAwsLambdaPolicyAndSetResponseAsAttribute(String path, String responseBody, HttpClient client)
+        throws InterruptedException {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("response from backend")));
+        awsLambdaMock.stubFor(post(anyUrl()).willReturn(ok("response from lambda")));
+
+        client
+            .rxRequest(HttpMethod.GET, path)
+            .flatMap(HttpClientRequest::rxSend)
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body.toString()).isEqualTo(responseBody);
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(getRequestedFor(urlPathEqualTo("/endpoint")));
+        awsLambdaMock.verify(postRequestedFor(urlMatching("/\\d{4}-\\d{2}-\\d{2}/functions/lambda-example/invocations")));
+    }
+
+    private static Stream<Arguments> providePath() {
+        return Stream.of(
+            Arguments.of("/on-request", 0),
+            Arguments.of("/on-request-content", 0),
+            Arguments.of("/on-response", 1),
+            Arguments.of("/on-response-content", 1)
+        );
+    }
+
+    private static Stream<Arguments> providePathAndResponse() {
+        return Stream.of(
+            Arguments.of("/on-request", "response from lambda"),
+            Arguments.of("/on-response", "response from lambda"),
+            Arguments.of("/on-response-content", "response from lambda"),
+            Arguments.of("/send-to-consumer", "noContent")
+        );
+    }
+}

--- a/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyV3CompatibilityIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyV3CompatibilityIntegrationTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.aws.lambda;
+
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.ExecutionMode;
+
+public class AwsLambdaPolicyV3CompatibilityIntegrationTest extends AwsLambdaPolicyIntegrationTest {
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+        super.configureGateway(gatewayConfigurationBuilder);
+        gatewayConfigurationBuilder.set("api.jupiterMode.enabled", "true");
+    }
+
+    @Override
+    public void configureApi(Api api) {
+        super.configureApi(api);
+        api.setExecutionMode(ExecutionMode.V3);
+    }
+}

--- a/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyV3IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyV3IntegrationTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.aws.lambda;
+
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.ExecutionMode;
+
+public class AwsLambdaPolicyV3IntegrationTest extends AwsLambdaPolicyIntegrationTest {
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+        super.configureGateway(gatewayConfigurationBuilder);
+        gatewayConfigurationBuilder.set("api.jupiterMode.enabled", "false");
+    }
+
+    @Override
+    public void configureApi(Api api) {
+        super.configureApi(api);
+        api.setExecutionMode(ExecutionMode.V3);
+    }
+}

--- a/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaTestPolicy.java
+++ b/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaTestPolicy.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.aws.lambda;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.lambda.AWSLambdaAsync;
+import com.amazonaws.services.lambda.AWSLambdaAsyncClientBuilder;
+
+/**
+ * This AwsLambdaTestPolicy policy has been created to be able to override the AWS Lambda client in order to use WireMock.
+ * By default the AwsLambdaPolicy uses the AWS SDK to create the client. This client is created in the initLambdaClient method
+ * and configure the endpoint using the configuration credentials and region. Using it, it'll try to call a real AWS Lambda endpoint
+ * which will return us a forbidden exception.
+ */
+public class AwsLambdaTestPolicy extends AwsLambdaPolicy {
+
+    public AwsLambdaTestPolicy(AwsLambdaTestPolicyConfiguration configuration) {
+        super(configuration);
+    }
+
+    @Override
+    protected AWSLambdaAsync initLambdaClient() {
+        return AWSLambdaAsyncClientBuilder
+            .standard()
+            .withCredentials(
+                new AWSStaticCredentialsProvider(new BasicAWSCredentials(configuration.getAccessKey(), configuration.getSecretKey()))
+            )
+            .withEndpointConfiguration(
+                new AwsClientBuilder.EndpointConfiguration(
+                    ((AwsLambdaTestPolicyConfiguration) this.configuration).getEndpoint(),
+                    this.configuration.getRegion()
+                )
+            )
+            .build();
+    }
+}

--- a/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaTestPolicyConfiguration.java
+++ b/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaTestPolicyConfiguration.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.aws.lambda;
+
+import io.gravitee.policy.aws.lambda.configuration.AwsLambdaPolicyConfiguration;
+import io.gravitee.policy.aws.lambda.configuration.PolicyScope;
+import io.gravitee.policy.aws.lambda.configuration.Variable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AwsLambdaTestPolicyConfiguration extends AwsLambdaPolicyConfiguration {
+
+    private PolicyScope scope = PolicyScope.REQUEST;
+
+    private String region = "us-east-1";
+
+    private String accessKey, secretKey;
+
+    private String function;
+
+    private String payload;
+
+    private List<Variable> variables = new ArrayList<>();
+
+    private boolean sendToConsumer;
+
+    private String endpoint;
+
+    public PolicyScope getScope() {
+        return scope;
+    }
+
+    public void setScope(PolicyScope scope) {
+        this.scope = scope;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public void setAccessKey(String accessKey) {
+        this.accessKey = accessKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public void setSecretKey(String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    public String getFunction() {
+        return function;
+    }
+
+    public void setFunction(String function) {
+        this.function = function;
+    }
+
+    public List<Variable> getVariables() {
+        return variables;
+    }
+
+    public void setVariables(List<Variable> variables) {
+        this.variables = variables;
+    }
+
+    public boolean isSendToConsumer() {
+        return sendToConsumer;
+    }
+
+    public void setSendToConsumer(boolean sendToConsumer) {
+        this.sendToConsumer = sendToConsumer;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+}

--- a/src/test/java/io/gravitee/policy/aws/lambda/CopyAwsLambdaAttributePolicy.java
+++ b/src/test/java/io/gravitee/policy/aws/lambda/CopyAwsLambdaAttributePolicy.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.aws.lambda;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.stream.BufferedReadWriteStream;
+import io.gravitee.gateway.api.stream.ReadWriteStream;
+import io.gravitee.gateway.api.stream.SimpleReadWriteStream;
+import io.gravitee.policy.api.annotations.OnResponseContent;
+
+public class CopyAwsLambdaAttributePolicy {
+
+    public static final String NO_AWS_LAMBDA_CONTENT_ATTRIBUTE = "noContent";
+
+    @OnResponseContent
+    public ReadWriteStream<Buffer> onResponseContent(ExecutionContext context) {
+        return new BufferedReadWriteStream() {
+            @Override
+            public SimpleReadWriteStream<Buffer> write(Buffer content) {
+                return this;
+            }
+
+            @Override
+            public void end() {
+                String content = NO_AWS_LAMBDA_CONTENT_ATTRIBUTE;
+                final Object awsContent = context.getAttribute("lambdaResponse");
+                if (awsContent != null) {
+                    content = awsContent.toString();
+                }
+                super.write(Buffer.buffer(content));
+                super.end();
+            }
+        };
+    }
+}

--- a/src/test/resources/apis/aws-lambda-on-request-content.json
+++ b/src/test/resources/apis/aws-lambda-on-request-content.json
@@ -1,0 +1,64 @@
+{
+  "id": "on-request-content-api",
+  "name": "on-request-content-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/on-request-content",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "on-request-content-api flow",
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "methods": [
+        "GET"
+      ],
+      "pre": [
+        {
+          "name": "AWS Lambda",
+          "description": "",
+          "enabled": true,
+          "policy": "aws-lambda-test-policy",
+          "configuration": {
+            "variables": [
+              {
+                "name": "lambdaResponse",
+                "value": "{#jsonPath(#lambdaResponse.content, '$')}"
+              }
+            ],
+            "secretKey": "secretKey",
+            "accessKey":"accessKey",
+            "payload": "{ \"key\": \"value\" }",
+            "scope": "REQUEST_CONTENT",
+            "function": "lambda-example",
+            "region": "us-east-1",
+            "sendToConsumer": false,
+            "endpoint": "http://localhost:9999"
+          }
+        }
+      ],
+      "post": [
+        {
+          "name": "Copy Aws Lambda Attribute",
+          "description": "",
+          "enabled": true,
+          "policy": "copy-aws-lambda-attribute",
+          "configuration": {}
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/apis/aws-lambda-on-request.json
+++ b/src/test/resources/apis/aws-lambda-on-request.json
@@ -1,0 +1,64 @@
+{
+  "id": "on-request-api",
+  "name": "on-request-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/on-request",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "on-request-api flow",
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "methods": [
+        "GET"
+      ],
+      "pre": [
+        {
+          "name": "AWS Lambda",
+          "description": "",
+          "enabled": true,
+          "policy": "aws-lambda-test-policy",
+          "configuration": {
+            "variables": [
+              {
+                "name": "lambdaResponse",
+                "value": "{#jsonPath(#lambdaResponse.content, '$')}"
+              }
+            ],
+            "secretKey": "secretKey",
+            "accessKey":"accessKey",
+            "payload": "{ \"key\": \"value\" }",
+            "scope": "REQUEST",
+            "function": "lambda-example",
+            "region": "us-east-1",
+            "sendToConsumer": false,
+            "endpoint": "http://localhost:9999"
+          }
+        }
+      ],
+      "post": [
+        {
+          "name": "Copy Aws Lambda Attribute",
+          "description": "",
+          "enabled": true,
+          "policy": "copy-aws-lambda-attribute",
+          "configuration": {}
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/apis/aws-lambda-on-response-content.json
+++ b/src/test/resources/apis/aws-lambda-on-response-content.json
@@ -1,0 +1,63 @@
+{
+  "id": "on-response-content-api",
+  "name": "on-response-content-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/on-response-content",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "on-response-content-api flow",
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "methods": [
+        "GET"
+      ],
+      "pre": [ ],
+      "post": [
+        {
+          "name": "AWS Lambda",
+          "description": "",
+          "enabled": true,
+          "policy": "aws-lambda-test-policy",
+          "configuration": {
+            "variables": [
+              {
+                "name": "lambdaResponse",
+                "value": "{#jsonPath(#lambdaResponse.content, '$')}"
+              }
+            ],
+            "secretKey": "secretKey",
+            "accessKey":"accessKey",
+            "payload": "{ \"key\": \"value\" }",
+            "scope": "RESPONSE_CONTENT",
+            "function": "lambda-example",
+            "region": "us-east-1",
+            "sendToConsumer": false,
+            "endpoint": "http://localhost:9999"
+          }
+        },
+        {
+          "name": "Copy Aws Lambda Attribute",
+          "description": "",
+          "enabled": true,
+          "policy": "copy-aws-lambda-attribute",
+          "configuration": {}
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/apis/aws-lambda-on-response.json
+++ b/src/test/resources/apis/aws-lambda-on-response.json
@@ -1,0 +1,63 @@
+{
+  "id": "on-response-api",
+  "name": "on-response-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/on-response",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "on-response-api flow",
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "methods": [
+        "GET"
+      ],
+      "pre": [ ],
+      "post": [
+        {
+          "name": "AWS Lambda",
+          "description": "",
+          "enabled": true,
+          "policy": "aws-lambda-test-policy",
+          "configuration": {
+            "variables": [
+              {
+                "name": "lambdaResponse",
+                "value": "{#jsonPath(#lambdaResponse.content, '$')}"
+              }
+            ],
+            "secretKey": "secretKey",
+            "accessKey":"accessKey",
+            "payload": "{ \"key\": \"value\" }",
+            "scope": "RESPONSE",
+            "function": "lambda-example",
+            "region": "us-east-1",
+            "sendToConsumer": false,
+            "endpoint": "http://localhost:9999"
+          }
+        },
+        {
+          "name": "Copy Aws Lambda Attribute",
+          "description": "",
+          "enabled": true,
+          "policy": "copy-aws-lambda-attribute",
+          "configuration": {}
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/apis/aws-lambda-with-send-to-consumer.json
+++ b/src/test/resources/apis/aws-lambda-with-send-to-consumer.json
@@ -1,0 +1,63 @@
+{
+  "id": "send-to-consumer-api",
+  "name": "send-to-consumer-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/send-to-consumer",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "send-to-consumer-api flow",
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "methods": [
+        "GET"
+      ],
+      "pre": [ ],
+      "post": [
+        {
+          "name": "AWS Lambda",
+          "description": "",
+          "enabled": true,
+          "policy": "aws-lambda-test-policy",
+          "configuration": {
+            "variables": [
+              {
+                "name": "lambdaResponse",
+                "value": "{#jsonPath(#lambdaResponse.content, '$')}"
+              }
+            ],
+            "secretKey": "secretKey",
+            "accessKey":"accessKey",
+            "payload": "{ \"key\": \"value\" }",
+            "scope": "REQUEST",
+            "function": "lambda-example",
+            "region": "us-east-1",
+            "sendToConsumer": true,
+            "endpoint": "http://localhost:9999"
+          }
+        },
+        {
+          "name": "Copy Aws Lambda Attribute",
+          "description": "",
+          "enabled": true,
+          "policy": "copy-aws-lambda-attribute",
+          "configuration": {}
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<!-- only gravitee Logs in debug -->
+	<logger name="io.gravitee" level="ERROR" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+
+	<!-- Root Logger -->
+	<root level="INFO">
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>


### PR DESCRIPTION
**Description**

Add integration tests to aws lambda policy.
Here we need to use a fake policy which inherit from the original one to be able to override the AWS Client endpoint. This one is constructed by default using the policy configuration and tries to connect on AWS for real using the credentials.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-aws-lambda/1.1.0/gravitee-policy-aws-lambda-1.1.0.zip)
  <!-- Version placeholder end -->
