### PR TITLE
feat(aws-lambda): Add support for STS to manage dynamic authenticatio…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.5.0
+    gravitee: gravitee-io/gravitee@4.1.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,30 +1,28 @@
 {
-  "extends": ["config:base"],
-  "rebaseWhen": "conflicted",
-  "baseBranches": ["master"],
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "ci"
-    },
-    {
-      "matchPackagePatterns": [
-        "com.amazonaws:aws-java-sdk-lambda"
-      ],
-      "matchUpdateTypes": ["patch"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "fix"
-    },
-    {
-      "matchDepTypes": ["test"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "fix"
-    }
-  ]
+    "extends": ["config:base"],
+    "rebaseWhen": "conflicted",
+    "baseBranches": ["master"],
+    "packageRules": [
+        {
+            "matchDatasources": ["orb"],
+            "matchUpdateTypes": ["patch", "minor"],
+            "automerge": true,
+            "automergeType": "branch",
+            "semanticCommitType": "ci"
+        },
+        {
+            "matchPackagePatterns": ["com.amazonaws:aws-java-sdk-lambda"],
+            "matchUpdateTypes": ["patch"],
+            "automerge": true,
+            "automergeType": "branch",
+            "semanticCommitType": "fix"
+        },
+        {
+            "matchDepTypes": ["test"],
+            "matchUpdateTypes": ["patch", "minor"],
+            "automerge": true,
+            "automergeType": "branch",
+            "semanticCommitType": "fix"
+        }
+    ]
 }

--- a/README.adoc
+++ b/README.adoc
@@ -83,6 +83,38 @@ By default, the lambda is called in addition to the backend, meaning the consume
 ^.^|boolean
 ^.^|false
 
+.^|invocationType
+^.^|X
+|RequestResponse (default) – Invoke the function synchronously. Keep the connection open until the function returns a response or times out. The API response includes the function response and additional data.
+Event – Invoke the function asynchronously. Send events that fail multiple times to the function's dead-letter queue (if one is configured). The API response only includes a status code.
+DryRun – Validate parameter values and verify that the user or role has permission to invoke the function.
+^.^|string
+^.^|RequestResponse
+
+.^|qualifier
+^.^|-
+|Specify a version or alias to invoke a published version of the function.
+^.^|string
+^.^|-
+
+.^|logType
+^.^|X
+|Set to Tail to include the execution log in the response. Applies to synchronously invoked functions only.
+^.^|string
+^.^|None
+
+.^|roleArn
+^.^|-
+|The arn of the role to be assumed. This is used when authentication is relying on the AWS Security Token Service (STS) to assume a Role and create temporary, short-lived sessions to use for authentication.
+^.^|string
+^.^|-
+
+.^|roleSessionName
+^.^|-
+|An identifier for the assumed role session (Only used when authentication is based on AWS Security Token Service (STS)
+^.^|string
+^.^|gravitee
+
 |===
 
 == Examples

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,15 +31,15 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.0</version>
+        <version>22.1.1</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>4.0.3</gravitee-bom.version>
+        <gravitee-bom.version>8.1.0</gravitee-bom.version>
         <gravitee-apim.version>4.3.7</gravitee-apim.version>
-        <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>2.1.0</gravitee-common.version>
+        <gravitee-common.version>4.4.0</gravitee-common.version>
         <aws-java-sdk.version>1.12.748</aws-java-sdk.version>
 
         <maven-plugin-assembly.version>3.5.0</maven-plugin-assembly.version>
@@ -130,6 +130,11 @@
             <groupId>io.gravitee.apim.gateway</groupId>
             <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
             <version>${gravitee-apim.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,11 @@
 
     <properties>
         <gravitee-bom.version>4.0.3</gravitee-bom.version>
-        <gravitee-apim.version>3.21.0-SNAPSHOT</gravitee-apim.version>
+        <gravitee-apim.version>4.3.7</gravitee-apim.version>
         <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-common.version>2.1.0</gravitee-common.version>
-        <aws-java-sdk-lambda.version>1.11.1034</aws-java-sdk-lambda.version>
+        <aws-java-sdk.version>1.12.748</aws-java-sdk.version>
 
         <maven-plugin-assembly.version>3.5.0</maven-plugin-assembly.version>
         <maven-plugin-prettier.version>0.19</maven-plugin-prettier.version>
@@ -90,7 +90,13 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-lambda</artifactId>
-            <version>${aws-java-sdk-lambda.version}</version>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
+            <version>${aws-java-sdk.version}</version>
         </dependency>
 
         <!-- Vert.x -->

--- a/src/assembly/policy-assembly.xml
+++ b/src/assembly/policy-assembly.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicy.java
+++ b/src/main/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicy.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -317,7 +317,7 @@ public class AwsLambdaPolicy {
         );
     }
 
-    private AWSLambdaAsync initLambdaClient() {
+    protected AWSLambdaAsync initLambdaClient() {
         AWSCredentialsProvider awsCredentialsProvider;
 
         if (configuration.getRoleArn() != null && !configuration.getRoleArn().isEmpty()) {

--- a/src/main/java/io/gravitee/policy/aws/lambda/LambdaInvoker.java
+++ b/src/main/java/io/gravitee/policy/aws/lambda/LambdaInvoker.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/aws/lambda/configuration/AwsLambdaPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/aws/lambda/configuration/AwsLambdaPolicyConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/aws/lambda/configuration/AwsLambdaPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/aws/lambda/configuration/AwsLambdaPolicyConfiguration.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.policy.aws.lambda.configuration;
 
+import com.amazonaws.services.lambda.model.InvocationType;
+import com.amazonaws.services.lambda.model.LogType;
 import io.gravitee.policy.api.PolicyConfiguration;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,6 +36,16 @@ public class AwsLambdaPolicyConfiguration implements PolicyConfiguration {
     private String function;
 
     private String payload;
+
+    private InvocationType invocationType = InvocationType.RequestResponse;
+
+    private String qualifier;
+
+    private String roleArn;
+
+    private String roleSessionName = "gravitee";
+
+    private LogType logType = LogType.None;
 
     private List<Variable> variables = new ArrayList<>();
 
@@ -101,5 +113,45 @@ public class AwsLambdaPolicyConfiguration implements PolicyConfiguration {
 
     public void setSendToConsumer(boolean sendToConsumer) {
         this.sendToConsumer = sendToConsumer;
+    }
+
+    public InvocationType getInvocationType() {
+        return invocationType;
+    }
+
+    public void setInvocationType(InvocationType invocationType) {
+        this.invocationType = invocationType;
+    }
+
+    public String getQualifier() {
+        return qualifier;
+    }
+
+    public void setQualifier(String qualifier) {
+        this.qualifier = qualifier;
+    }
+
+    public String getRoleArn() {
+        return roleArn;
+    }
+
+    public void setRoleArn(String roleArn) {
+        this.roleArn = roleArn;
+    }
+
+    public String getRoleSessionName() {
+        return roleSessionName;
+    }
+
+    public void setRoleSessionName(String roleSessionName) {
+        this.roleSessionName = roleSessionName;
+    }
+
+    public LogType getLogType() {
+        return logType;
+    }
+
+    public void setLogType(LogType logType) {
+        this.logType = logType;
     }
 }

--- a/src/main/java/io/gravitee/policy/aws/lambda/configuration/PolicyScope.java
+++ b/src/main/java/io/gravitee/policy/aws/lambda/configuration/PolicyScope.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/aws/lambda/configuration/Variable.java
+++ b/src/main/java/io/gravitee/policy/aws/lambda/configuration/Variable.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/aws/lambda/el/LambdaResponse.java
+++ b/src/main/java/io/gravitee/policy/aws/lambda/el/LambdaResponse.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/aws/lambda/sdk/AWSCredentialsProviderChain.java
+++ b/src/main/java/io/gravitee/policy/aws/lambda/sdk/AWSCredentialsProviderChain.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/aws/lambda/sdk/AWSCredentialsProviderChain.java
+++ b/src/main/java/io/gravitee/policy/aws/lambda/sdk/AWSCredentialsProviderChain.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.aws.lambda.sdk;
+
+import com.amazonaws.auth.*;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class AWSCredentialsProviderChain extends com.amazonaws.auth.AWSCredentialsProviderChain {
+
+    private static final AWSCredentialsProviderChain INSTANCE = new AWSCredentialsProviderChain();
+
+    public AWSCredentialsProviderChain(AWSCredentialsProvider[] providers) {
+        super(providers);
+    }
+
+    public AWSCredentialsProviderChain() {
+        this(
+            new AWSCredentialsProvider[] {
+                new EnvironmentVariableCredentialsProvider(),
+                new SystemPropertiesCredentialsProvider(),
+                new ProfileCredentialsProvider(),
+                new EC2ContainerCredentialsProviderWrapper(),
+                new InstanceProfileCredentialsProvider(false),
+            }
+        );
+    }
+
+    public static AWSCredentialsProviderChain getInstance() {
+        return INSTANCE;
+    }
+}

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,115 +1,106 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:policy:aws:lambda:configuration:AwsLambdaPolicyConfiguration",
-  "properties" : {
-    "scope" : {
-      "title": "Scope",
-      "description": "Execute policy on <strong>request</strong> (HEAD) phase, <strong>response</strong> (HEAD) phase, <strong>request_content</strong> (includes payload) phase, <strong>response content</strong> (includes payload) phase.",
-      "type" : "string",
-      "default": "REQUEST",
-      "enum" : [ "REQUEST", "RESPONSE", "REQUEST_CONTENT", "RESPONSE_CONTENT" ]
-    },
-    "region": {
-      "title": "AWS Region",
-      "description": "AWS Region",
-      "default": "us-east-1",
-      "type" : "string"
-    },
-    "accessKey": {
-      "title": "AWS Access Key",
-      "description": "AWS Access Key",
-      "type" : "string"
-    },
-    "secretKey": {
-      "title": "AWS Secret Key",
-      "description": "AWS Secret Key",
-      "type" : "string"
-    },
-    "function": {
-      "title": "AWS Lambda Function",
-      "description": "AWS Lambda function to call",
-      "type" : "string"
-    },
-    "invocationType": {
-      "title": "Invocation Type",
-      "description": "RequestResponse (default) – Invoke the function synchronously. Keep the connection open until the function returns a response or times out. The API response includes the function response and additional data.\nEvent – Invoke the function asynchronously. Send events that fail multiple times to the function's dead-letter queue (if one is configured). The API response only includes a status code.\nDryRun – Validate parameter values and verify that the user or role has permission to invoke the function.",
-      "type" : "string",
-      "default": "RequestResponse",
-      "enum" : [ "RequestResponse", "Event", "DryRun" ]
-    },
-    "qualifier": {
-      "title": "Qualifier",
-      "description": "Specify a version or alias to invoke a published version of the function.",
-      "type" : "string"
-    },
-    "logType": {
-      "title": "Log Type",
-      "description": "Set to Tail to include the execution log in the response. Applies to synchronously invoked functions only.",
-      "type" : "string",
-      "default": "None",
-      "enum" : [ "None", "Tail" ]
-    },
-    "roleArn": {
-      "title": "Assume Role ARN",
-      "description": "The arn of the role to be assumed. This is used when authentication is relying on the AWS Security Token Service (STS) to assume a Role and create temporary, short-lived sessions to use for authentication.",
-      "type" : "string"
-    },
-    "roleSessionName": {
-      "title": "Role Session Name",
-      "description": "An identifier for the assumed role session (Only used when authentication is based on AWS Security Token Service (STS)",
-      "default": "gravitee",
-      "type" : "string"
-    },
-    "payload" : {
-      "title": "Lambda request payload",
-      "type" : "string",
-      "x-schema-form": {
-        "type": "codemirror",
-        "codemirrorOptions": {
-          "placeholder": "Put payload here",
-          "lineWrapping": true,
-          "lineNumbers": true,
-          "allowDropFileTypes": true,
-          "autoCloseTags": true
+    "type": "object",
+    "id": "urn:jsonschema:io:gravitee:policy:aws:lambda:configuration:AwsLambdaPolicyConfiguration",
+    "properties": {
+        "scope": {
+            "title": "Scope",
+            "description": "Execute policy on <strong>request</strong> (HEAD) phase, <strong>response</strong> (HEAD) phase, <strong>request_content</strong> (includes payload) phase, <strong>response content</strong> (includes payload) phase.",
+            "type": "string",
+            "default": "REQUEST",
+            "enum": ["REQUEST", "RESPONSE", "REQUEST_CONTENT", "RESPONSE_CONTENT"]
+        },
+        "region": {
+            "title": "AWS Region",
+            "description": "AWS Region",
+            "default": "us-east-1",
+            "type": "string"
+        },
+        "accessKey": {
+            "title": "AWS Access Key",
+            "description": "AWS Access Key",
+            "type": "string"
+        },
+        "secretKey": {
+            "title": "AWS Secret Key",
+            "description": "AWS Secret Key",
+            "type": "string"
+        },
+        "function": {
+            "title": "AWS Lambda Function",
+            "description": "AWS Lambda function to call",
+            "type": "string"
+        },
+        "invocationType": {
+            "title": "Invocation Type",
+            "description": "RequestResponse (default) – Invoke the function synchronously. Keep the connection open until the function returns a response or times out. The API response includes the function response and additional data.\nEvent – Invoke the function asynchronously. Send events that fail multiple times to the function's dead-letter queue (if one is configured). The API response only includes a status code.\nDryRun – Validate parameter values and verify that the user or role has permission to invoke the function.",
+            "type": "string",
+            "default": "RequestResponse",
+            "enum": ["RequestResponse", "Event", "DryRun"]
+        },
+        "qualifier": {
+            "title": "Qualifier",
+            "description": "Specify a version or alias to invoke a published version of the function.",
+            "type": "string"
+        },
+        "logType": {
+            "title": "Log Type",
+            "description": "Set to Tail to include the execution log in the response. Applies to synchronously invoked functions only.",
+            "type": "string",
+            "default": "None",
+            "enum": ["None", "Tail"]
+        },
+        "roleArn": {
+            "title": "Assume Role ARN",
+            "description": "The arn of the role to be assumed. This is used when authentication is relying on the AWS Security Token Service (STS) to assume a Role and create temporary, short-lived sessions to use for authentication.",
+            "type": "string"
+        },
+        "roleSessionName": {
+            "title": "Role Session Name",
+            "description": "An identifier for the assumed role session (Only used when authentication is based on AWS Security Token Service (STS)",
+            "default": "gravitee",
+            "type": "string"
+        },
+        "payload": {
+            "title": "Lambda request payload",
+            "type": "string",
+            "x-schema-form": {
+                "type": "codemirror",
+                "codemirrorOptions": {
+                    "placeholder": "Put payload here",
+                    "lineWrapping": true,
+                    "lineNumbers": true,
+                    "allowDropFileTypes": true,
+                    "autoCloseTags": true
+                }
+            }
+        },
+        "variables": {
+            "type": "array",
+            "title": "Context variables",
+            "items": {
+                "type": "object",
+                "id": "urn:jsonschema:io:gravitee:policy:aws:lambda:configuration:Variable",
+                "title": "Variable",
+                "properties": {
+                    "name": {
+                        "title": "Name",
+                        "type": "string"
+                    },
+                    "value": {
+                        "title": "Value",
+                        "type": "string",
+                        "default": "{#jsonPath(#lambdaResponse.content, '$.field')}"
+                    }
+                }
+            },
+            "required": ["name", "value"]
+        },
+        "sendToConsumer": {
+            "title": "Send lambda function result to consumer",
+            "description": "Check this option if you want to send the response of the lambda to the initial consumer without going to the final upstream (endpoints) selected by the gateway.",
+            "type": "boolean",
+            "default": false
         }
-      }
     },
-    "variables" : {
-      "type" : "array",
-      "title": "Context variables",
-      "items" : {
-        "type" : "object",
-        "id" : "urn:jsonschema:io:gravitee:policy:aws:lambda:configuration:Variable",
-        "title": "Variable",
-        "properties" : {
-          "name" : {
-            "title": "Name",
-            "type" : "string"
-          },
-          "value" : {
-            "title": "Value",
-            "type" : "string",
-            "default": "{#jsonPath(#lambdaResponse.content, '$.field')}"
-          }
-        }
-      },
-      "required": [
-        "name",
-        "value"
-      ]
-    },
-    "sendToConsumer": {
-      "title": "Send lambda function result to consumer",
-      "description": "Check this option if you want to send the response of the lambda to the initial consumer without going to the final upstream (endpoints) selected by the gateway.",
-      "type" : "boolean",
-      "default": false
-    }
-  },
-  "required": [
-    "scope",
-    "region",
-    "function",
-    "invocationType",
-    "logType"
-  ]
+    "required": ["scope", "region", "function", "invocationType", "logType"]
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -30,6 +30,36 @@
       "description": "AWS Lambda function to call",
       "type" : "string"
     },
+    "invocationType": {
+      "title": "Invocation Type",
+      "description": "RequestResponse (default) – Invoke the function synchronously. Keep the connection open until the function returns a response or times out. The API response includes the function response and additional data.\nEvent – Invoke the function asynchronously. Send events that fail multiple times to the function's dead-letter queue (if one is configured). The API response only includes a status code.\nDryRun – Validate parameter values and verify that the user or role has permission to invoke the function.",
+      "type" : "string",
+      "default": "RequestResponse",
+      "enum" : [ "RequestResponse", "Event", "DryRun" ]
+    },
+    "qualifier": {
+      "title": "Qualifier",
+      "description": "Specify a version or alias to invoke a published version of the function.",
+      "type" : "string"
+    },
+    "logType": {
+      "title": "Log Type",
+      "description": "Set to Tail to include the execution log in the response. Applies to synchronously invoked functions only.",
+      "type" : "string",
+      "default": "None",
+      "enum" : [ "None", "Tail" ]
+    },
+    "roleArn": {
+      "title": "Assume Role ARN",
+      "description": "The arn of the role to be assumed. This is used when authentication is relying on the AWS Security Token Service (STS) to assume a Role and create temporary, short-lived sessions to use for authentication.",
+      "type" : "string"
+    },
+    "roleSessionName": {
+      "title": "Role Session Name",
+      "description": "An identifier for the assumed role session (Only used when authentication is based on AWS Security Token Service (STS)",
+      "default": "gravitee",
+      "type" : "string"
+    },
     "payload" : {
       "title": "Lambda request payload",
       "type" : "string",
@@ -78,6 +108,8 @@
   "required": [
     "scope",
     "region",
-    "function"
+    "function",
+    "invocationType",
+    "logType"
   ]
 }

--- a/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyIntegrationTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,27 +18,38 @@ package io.gravitee.policy.aws.lambda;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
 import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
 import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.el.TemplateContext;
+import io.gravitee.el.TemplateEngine;
+import io.gravitee.gateway.reactive.api.context.ExecutionContext;
 import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.aws.lambda.configuration.AwsLambdaPolicyConfiguration;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.rxjava3.core.http.HttpClient;
 import io.vertx.rxjava3.core.http.HttpClientRequest;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.junit.Before;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 @GatewayTest
 @DeployApi(
@@ -50,7 +61,7 @@ import org.junit.jupiter.params.provider.MethodSource;
         "/apis/aws-lambda-with-send-to-consumer.json",
     }
 )
-public class AwsLambdaPolicyIntegrationTest extends AbstractGatewayTest {
+public class AwsLambdaPolicyIntegrationTest extends AbstractPolicyTest<AwsLambdaPolicy, AwsLambdaPolicyConfiguration> {
 
     private WireMockServer awsLambdaMock;
 
@@ -84,7 +95,7 @@ public class AwsLambdaPolicyIntegrationTest extends AbstractGatewayTest {
     @Override
     public void configureApi(ReactableApi<?> api, Class<?> apiDefinitionClass) {
         if (apiDefinitionClass.isAssignableFrom(Api.class)) {
-            ((Api) api.getDefinition()).setExecutionMode(ExecutionMode.JUPITER);
+            ((Api) api.getDefinition()).setExecutionMode(ExecutionMode.V3);
             ((Api) api.getDefinition()).getFlows()
                 .forEach(flow -> {
                     flow

--- a/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyV3CompatibilityIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyV3CompatibilityIntegrationTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyV3IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyV3IntegrationTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaTestPolicy.java
+++ b/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaTestPolicy.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaTestPolicyConfiguration.java
+++ b/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaTestPolicyConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +15,8 @@
  */
 package io.gravitee.policy.aws.lambda;
 
+import com.amazonaws.services.lambda.model.InvocationType;
+import com.amazonaws.services.lambda.model.LogType;
 import io.gravitee.policy.aws.lambda.configuration.AwsLambdaPolicyConfiguration;
 import io.gravitee.policy.aws.lambda.configuration.PolicyScope;
 import io.gravitee.policy.aws.lambda.configuration.Variable;
@@ -33,11 +35,61 @@ public class AwsLambdaTestPolicyConfiguration extends AwsLambdaPolicyConfigurati
 
     private String payload;
 
+    private InvocationType invocationType = InvocationType.RequestResponse;
+
+    private String qualifier;
+
+    private String roleArn;
+
+    private String roleSessionName = "gravitee";
+
+    private LogType logType = LogType.None;
+
     private List<Variable> variables = new ArrayList<>();
 
     private boolean sendToConsumer;
 
     private String endpoint;
+
+    public InvocationType getInvocationType() {
+        return invocationType;
+    }
+
+    public void setInvocationType(InvocationType invocationType) {
+        this.invocationType = invocationType;
+    }
+
+    public String getQualifier() {
+        return qualifier;
+    }
+
+    public void setQualifier(String qualifier) {
+        this.qualifier = qualifier;
+    }
+
+    public String getRoleArn() {
+        return roleArn;
+    }
+
+    public void setRoleArn(String roleArn) {
+        this.roleArn = roleArn;
+    }
+
+    public String getRoleSessionName() {
+        return roleSessionName;
+    }
+
+    public void setRoleSessionName(String roleSessionName) {
+        this.roleSessionName = roleSessionName;
+    }
+
+    public LogType getLogType() {
+        return logType;
+    }
+
+    public void setLogType(LogType logType) {
+        this.logType = logType;
+    }
 
     public PolicyScope getScope() {
         return scope;

--- a/src/test/java/io/gravitee/policy/aws/lambda/CopyAwsLambdaAttributePolicy.java
+++ b/src/test/java/io/gravitee/policy/aws/lambda/CopyAwsLambdaAttributePolicy.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/apis/aws-lambda-on-request-content.json
+++ b/src/test/resources/apis/aws-lambda-on-request-content.json
@@ -1,64 +1,62 @@
 {
-  "id": "on-request-content-api",
-  "name": "on-request-content-api",
-  "gravitee": "2.0.0",
-  "proxy": {
-    "context_path": "/on-request-content",
-    "endpoints": [
-      {
-        "name": "default",
-        "target": "http://localhost:8080/endpoint",
-        "http": {
-          "connectTimeout": 3000,
-          "readTimeout": 60000
-        }
-      }
-    ]
-  },
-  "flows": [
-    {
-      "name": "on-request-content-api flow",
-      "enabled": true,
-      "path-operator": {
-        "path": "/",
-        "operator": "STARTS_WITH"
-      },
-      "methods": [
-        "GET"
-      ],
-      "pre": [
+    "id": "on-request-content-api",
+    "name": "on-request-content-api",
+    "gravitee": "2.0.0",
+    "proxy": {
+        "context_path": "/on-request-content",
+        "endpoints": [
+            {
+                "name": "default",
+                "target": "http://localhost:8080/endpoint",
+                "http": {
+                    "connectTimeout": 3000,
+                    "readTimeout": 60000
+                }
+            }
+        ]
+    },
+    "flows": [
         {
-          "name": "AWS Lambda",
-          "description": "",
-          "enabled": true,
-          "policy": "aws-lambda-test-policy",
-          "configuration": {
-            "variables": [
-              {
-                "name": "lambdaResponse",
-                "value": "{#jsonPath(#lambdaResponse.content, '$')}"
-              }
+            "name": "on-request-content-api flow",
+            "enabled": true,
+            "path-operator": {
+                "path": "/",
+                "operator": "STARTS_WITH"
+            },
+            "methods": ["GET"],
+            "pre": [
+                {
+                    "name": "AWS Lambda",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "aws-lambda-test-policy",
+                    "configuration": {
+                        "variables": [
+                            {
+                                "name": "lambdaResponse",
+                                "value": "{#jsonPath(#lambdaResponse.content, '$')}"
+                            }
+                        ],
+                        "secretKey": "secretKey",
+                        "accessKey": "accessKey",
+                        "payload": "{ \"key\": \"value\" }",
+                        "scope": "REQUEST_CONTENT",
+                        "function": "lambda-example",
+                        "region": "us-east-1",
+                        "sendToConsumer": false,
+                        "endpoint": "http://localhost:9999"
+                    }
+                }
             ],
-            "secretKey": "secretKey",
-            "accessKey":"accessKey",
-            "payload": "{ \"key\": \"value\" }",
-            "scope": "REQUEST_CONTENT",
-            "function": "lambda-example",
-            "region": "us-east-1",
-            "sendToConsumer": false,
-            "endpoint": "http://localhost:9999"
-          }
+            "post": [
+                {
+                    "name": "Copy Aws Lambda Attribute",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "copy-aws-lambda-attribute",
+                    "configuration": {}
+                }
+            ]
         }
-      ],
-      "post": [
-        {
-          "name": "Copy Aws Lambda Attribute",
-          "description": "",
-          "enabled": true,
-          "policy": "copy-aws-lambda-attribute",
-          "configuration": {}
-        }
-      ]
-    }
-  ]
+    ]
 }

--- a/src/test/resources/apis/aws-lambda-on-request.json
+++ b/src/test/resources/apis/aws-lambda-on-request.json
@@ -1,64 +1,62 @@
 {
-  "id": "on-request-api",
-  "name": "on-request-api",
-  "gravitee": "2.0.0",
-  "proxy": {
-    "context_path": "/on-request",
-    "endpoints": [
-      {
-        "name": "default",
-        "target": "http://localhost:8080/endpoint",
-        "http": {
-          "connectTimeout": 3000,
-          "readTimeout": 60000
-        }
-      }
-    ]
-  },
-  "flows": [
-    {
-      "name": "on-request-api flow",
-      "enabled": true,
-      "path-operator": {
-        "path": "/",
-        "operator": "STARTS_WITH"
-      },
-      "methods": [
-        "GET"
-      ],
-      "pre": [
+    "id": "on-request-api",
+    "name": "on-request-api",
+    "gravitee": "2.0.0",
+    "proxy": {
+        "context_path": "/on-request",
+        "endpoints": [
+            {
+                "name": "default",
+                "target": "http://localhost:8080/endpoint",
+                "http": {
+                    "connectTimeout": 3000,
+                    "readTimeout": 60000
+                }
+            }
+        ]
+    },
+    "flows": [
         {
-          "name": "AWS Lambda",
-          "description": "",
-          "enabled": true,
-          "policy": "aws-lambda-test-policy",
-          "configuration": {
-            "variables": [
-              {
-                "name": "lambdaResponse",
-                "value": "{#jsonPath(#lambdaResponse.content, '$')}"
-              }
+            "name": "on-request-api flow",
+            "enabled": true,
+            "path-operator": {
+                "path": "/",
+                "operator": "STARTS_WITH"
+            },
+            "methods": ["GET"],
+            "pre": [
+                {
+                    "name": "AWS Lambda",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "aws-lambda-test-policy",
+                    "configuration": {
+                        "variables": [
+                            {
+                                "name": "lambdaResponse",
+                                "value": "{#jsonPath(#lambdaResponse.content, '$')}"
+                            }
+                        ],
+                        "secretKey": "secretKey",
+                        "accessKey": "accessKey",
+                        "payload": "{ \"key\": \"value\" }",
+                        "scope": "REQUEST",
+                        "function": "lambda-example",
+                        "region": "us-east-1",
+                        "sendToConsumer": false,
+                        "endpoint": "http://localhost:9999"
+                    }
+                }
             ],
-            "secretKey": "secretKey",
-            "accessKey":"accessKey",
-            "payload": "{ \"key\": \"value\" }",
-            "scope": "REQUEST",
-            "function": "lambda-example",
-            "region": "us-east-1",
-            "sendToConsumer": false,
-            "endpoint": "http://localhost:9999"
-          }
+            "post": [
+                {
+                    "name": "Copy Aws Lambda Attribute",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "copy-aws-lambda-attribute",
+                    "configuration": {}
+                }
+            ]
         }
-      ],
-      "post": [
-        {
-          "name": "Copy Aws Lambda Attribute",
-          "description": "",
-          "enabled": true,
-          "policy": "copy-aws-lambda-attribute",
-          "configuration": {}
-        }
-      ]
-    }
-  ]
+    ]
 }

--- a/src/test/resources/apis/aws-lambda-on-response-content.json
+++ b/src/test/resources/apis/aws-lambda-on-response-content.json
@@ -1,63 +1,61 @@
 {
-  "id": "on-response-content-api",
-  "name": "on-response-content-api",
-  "gravitee": "2.0.0",
-  "proxy": {
-    "context_path": "/on-response-content",
-    "endpoints": [
-      {
-        "name": "default",
-        "target": "http://localhost:8080/endpoint",
-        "http": {
-          "connectTimeout": 3000,
-          "readTimeout": 60000
+    "id": "on-response-content-api",
+    "name": "on-response-content-api",
+    "gravitee": "2.0.0",
+    "proxy": {
+        "context_path": "/on-response-content",
+        "endpoints": [
+            {
+                "name": "default",
+                "target": "http://localhost:8080/endpoint",
+                "http": {
+                    "connectTimeout": 3000,
+                    "readTimeout": 60000
+                }
+            }
+        ]
+    },
+    "flows": [
+        {
+            "name": "on-response-content-api flow",
+            "enabled": true,
+            "path-operator": {
+                "path": "/",
+                "operator": "STARTS_WITH"
+            },
+            "methods": ["GET"],
+            "pre": [],
+            "post": [
+                {
+                    "name": "AWS Lambda",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "aws-lambda-test-policy",
+                    "configuration": {
+                        "variables": [
+                            {
+                                "name": "lambdaResponse",
+                                "value": "{#jsonPath(#lambdaResponse.content, '$')}"
+                            }
+                        ],
+                        "secretKey": "secretKey",
+                        "accessKey": "accessKey",
+                        "payload": "{ \"key\": \"value\" }",
+                        "scope": "RESPONSE_CONTENT",
+                        "function": "lambda-example",
+                        "region": "us-east-1",
+                        "sendToConsumer": false,
+                        "endpoint": "http://localhost:9999"
+                    }
+                },
+                {
+                    "name": "Copy Aws Lambda Attribute",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "copy-aws-lambda-attribute",
+                    "configuration": {}
+                }
+            ]
         }
-      }
     ]
-  },
-  "flows": [
-    {
-      "name": "on-response-content-api flow",
-      "enabled": true,
-      "path-operator": {
-        "path": "/",
-        "operator": "STARTS_WITH"
-      },
-      "methods": [
-        "GET"
-      ],
-      "pre": [ ],
-      "post": [
-        {
-          "name": "AWS Lambda",
-          "description": "",
-          "enabled": true,
-          "policy": "aws-lambda-test-policy",
-          "configuration": {
-            "variables": [
-              {
-                "name": "lambdaResponse",
-                "value": "{#jsonPath(#lambdaResponse.content, '$')}"
-              }
-            ],
-            "secretKey": "secretKey",
-            "accessKey":"accessKey",
-            "payload": "{ \"key\": \"value\" }",
-            "scope": "RESPONSE_CONTENT",
-            "function": "lambda-example",
-            "region": "us-east-1",
-            "sendToConsumer": false,
-            "endpoint": "http://localhost:9999"
-          }
-        },
-        {
-          "name": "Copy Aws Lambda Attribute",
-          "description": "",
-          "enabled": true,
-          "policy": "copy-aws-lambda-attribute",
-          "configuration": {}
-        }
-      ]
-    }
-  ]
 }

--- a/src/test/resources/apis/aws-lambda-on-response.json
+++ b/src/test/resources/apis/aws-lambda-on-response.json
@@ -1,63 +1,61 @@
 {
-  "id": "on-response-api",
-  "name": "on-response-api",
-  "gravitee": "2.0.0",
-  "proxy": {
-    "context_path": "/on-response",
-    "endpoints": [
-      {
-        "name": "default",
-        "target": "http://localhost:8080/endpoint",
-        "http": {
-          "connectTimeout": 3000,
-          "readTimeout": 60000
+    "id": "on-response-api",
+    "name": "on-response-api",
+    "gravitee": "2.0.0",
+    "proxy": {
+        "context_path": "/on-response",
+        "endpoints": [
+            {
+                "name": "default",
+                "target": "http://localhost:8080/endpoint",
+                "http": {
+                    "connectTimeout": 3000,
+                    "readTimeout": 60000
+                }
+            }
+        ]
+    },
+    "flows": [
+        {
+            "name": "on-response-api flow",
+            "enabled": true,
+            "path-operator": {
+                "path": "/",
+                "operator": "STARTS_WITH"
+            },
+            "methods": ["GET"],
+            "pre": [],
+            "post": [
+                {
+                    "name": "AWS Lambda",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "aws-lambda-test-policy",
+                    "configuration": {
+                        "variables": [
+                            {
+                                "name": "lambdaResponse",
+                                "value": "{#jsonPath(#lambdaResponse.content, '$')}"
+                            }
+                        ],
+                        "secretKey": "secretKey",
+                        "accessKey": "accessKey",
+                        "payload": "{ \"key\": \"value\" }",
+                        "scope": "RESPONSE",
+                        "function": "lambda-example",
+                        "region": "us-east-1",
+                        "sendToConsumer": false,
+                        "endpoint": "http://localhost:9999"
+                    }
+                },
+                {
+                    "name": "Copy Aws Lambda Attribute",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "copy-aws-lambda-attribute",
+                    "configuration": {}
+                }
+            ]
         }
-      }
     ]
-  },
-  "flows": [
-    {
-      "name": "on-response-api flow",
-      "enabled": true,
-      "path-operator": {
-        "path": "/",
-        "operator": "STARTS_WITH"
-      },
-      "methods": [
-        "GET"
-      ],
-      "pre": [ ],
-      "post": [
-        {
-          "name": "AWS Lambda",
-          "description": "",
-          "enabled": true,
-          "policy": "aws-lambda-test-policy",
-          "configuration": {
-            "variables": [
-              {
-                "name": "lambdaResponse",
-                "value": "{#jsonPath(#lambdaResponse.content, '$')}"
-              }
-            ],
-            "secretKey": "secretKey",
-            "accessKey":"accessKey",
-            "payload": "{ \"key\": \"value\" }",
-            "scope": "RESPONSE",
-            "function": "lambda-example",
-            "region": "us-east-1",
-            "sendToConsumer": false,
-            "endpoint": "http://localhost:9999"
-          }
-        },
-        {
-          "name": "Copy Aws Lambda Attribute",
-          "description": "",
-          "enabled": true,
-          "policy": "copy-aws-lambda-attribute",
-          "configuration": {}
-        }
-      ]
-    }
-  ]
 }

--- a/src/test/resources/apis/aws-lambda-with-send-to-consumer.json
+++ b/src/test/resources/apis/aws-lambda-with-send-to-consumer.json
@@ -1,63 +1,61 @@
 {
-  "id": "send-to-consumer-api",
-  "name": "send-to-consumer-api",
-  "gravitee": "2.0.0",
-  "proxy": {
-    "context_path": "/send-to-consumer",
-    "endpoints": [
-      {
-        "name": "default",
-        "target": "http://localhost:8080/endpoint",
-        "http": {
-          "connectTimeout": 3000,
-          "readTimeout": 60000
+    "id": "send-to-consumer-api",
+    "name": "send-to-consumer-api",
+    "gravitee": "2.0.0",
+    "proxy": {
+        "context_path": "/send-to-consumer",
+        "endpoints": [
+            {
+                "name": "default",
+                "target": "http://localhost:8080/endpoint",
+                "http": {
+                    "connectTimeout": 3000,
+                    "readTimeout": 60000
+                }
+            }
+        ]
+    },
+    "flows": [
+        {
+            "name": "send-to-consumer-api flow",
+            "enabled": true,
+            "path-operator": {
+                "path": "/",
+                "operator": "STARTS_WITH"
+            },
+            "methods": ["GET"],
+            "pre": [],
+            "post": [
+                {
+                    "name": "AWS Lambda",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "aws-lambda-test-policy",
+                    "configuration": {
+                        "variables": [
+                            {
+                                "name": "lambdaResponse",
+                                "value": "{#jsonPath(#lambdaResponse.content, '$')}"
+                            }
+                        ],
+                        "secretKey": "secretKey",
+                        "accessKey": "accessKey",
+                        "payload": "{ \"key\": \"value\" }",
+                        "scope": "REQUEST",
+                        "function": "lambda-example",
+                        "region": "us-east-1",
+                        "sendToConsumer": true,
+                        "endpoint": "http://localhost:9999"
+                    }
+                },
+                {
+                    "name": "Copy Aws Lambda Attribute",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "copy-aws-lambda-attribute",
+                    "configuration": {}
+                }
+            ]
         }
-      }
     ]
-  },
-  "flows": [
-    {
-      "name": "send-to-consumer-api flow",
-      "enabled": true,
-      "path-operator": {
-        "path": "/",
-        "operator": "STARTS_WITH"
-      },
-      "methods": [
-        "GET"
-      ],
-      "pre": [ ],
-      "post": [
-        {
-          "name": "AWS Lambda",
-          "description": "",
-          "enabled": true,
-          "policy": "aws-lambda-test-policy",
-          "configuration": {
-            "variables": [
-              {
-                "name": "lambdaResponse",
-                "value": "{#jsonPath(#lambdaResponse.content, '$')}"
-              }
-            ],
-            "secretKey": "secretKey",
-            "accessKey":"accessKey",
-            "payload": "{ \"key\": \"value\" }",
-            "scope": "REQUEST",
-            "function": "lambda-example",
-            "region": "us-east-1",
-            "sendToConsumer": true,
-            "endpoint": "http://localhost:9999"
-          }
-        },
-        {
-          "name": "Copy Aws Lambda Attribute",
-          "description": "",
-          "enabled": true,
-          "policy": "copy-aws-lambda-attribute",
-          "configuration": {}
-        }
-      ]
-    }
-  ]
 }


### PR DESCRIPTION
…n credentials

**Issue**

https://gravitee.atlassian.net/browse/APIM-3636

**Description**

Add support for AWS STS: https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.0-apim-3636-aws-credentials-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-aws-lambda/1.2.0-apim-3636-aws-credentials-SNAPSHOT/gravitee-policy-aws-lambda-1.2.0-apim-3636-aws-credentials-SNAPSHOT.zip)
  <!-- Version placeholder end -->
