### PR TITLE
fix(aws-lambda): bump gravitee version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,11 +35,11 @@
     </parent>
 
     <properties>
-        <gravitee-bom.version>8.1.0</gravitee-bom.version>
-        <gravitee-apim.version>4.3.7</gravitee-apim.version>
-        <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
+        <gravitee-bom.version>6.0.3</gravitee-bom.version>
+        <gravitee-apim.version>4.0.0</gravitee-apim.version>
+        <gravitee-gateway-api.version>3.2.3</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>4.4.0</gravitee-common.version>
+        <gravitee-common.version>3.4.1</gravitee-common.version>
         <aws-java-sdk.version>1.12.748</aws-java-sdk.version>
 
         <maven-plugin-assembly.version>3.5.0</maven-plugin-assembly.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3636

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.1-apim-3636-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-aws-lambda/1.2.1-apim-3636-SNAPSHOT/gravitee-policy-aws-lambda-1.2.1-apim-3636-SNAPSHOT.zip)
  <!-- Version placeholder end -->
