### PR TITLE
chore(deps): bump gravitee-apim to 4.8.0-SNAPSHOT

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,7 +28,8 @@ endif::[]
 |===
 |Plugin version    | APIM version       | JDK version
 
-| 2.x              | 4.7.x and later    | 21
+| 3.x              | 4.8.x and later    | 21
+| 2.x              | 4.7.x              | 21
 | 1.x              | 3.x to 4.6.x       | 17
 
 |===

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     </parent>
 
     <properties>
-        <gravitee-apim-bom.version>4.7.3</gravitee-apim-bom.version>
+        <gravitee-apim-bom.version>4.8.0-SNAPSHOT</gravitee-apim-bom.version>
         <gravitee-entrypoint-http-get.version>2.1.0</gravitee-entrypoint-http-get.version>
         <gravitee-reactor-message.version>6.0.1</gravitee-reactor-message.version>
         <aws-java-sdk.version>2.31.26</aws-java-sdk.version>


### PR DESCRIPTION
**Description**

We need to build a new version of the policy for APIM 4.8 because ReactableApi is now an interface (it was an abstract class before).
Without recompiling, the policy is throwing a `java.lang.IncompatibleClassChangeError`



**Additional context**

BREAKING CHANGE: require at least APIM 4.8

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-bump-apim-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-aws-lambda/3.0.0-bump-apim-SNAPSHOT/gravitee-policy-aws-lambda-3.0.0-bump-apim-SNAPSHOT.zip)
  <!-- Version placeholder end -->
