### PR TITLE
fix: do not use DefaultCredentialsProvider when no access key and secret key are used

### DIFF
--- a/src/main/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyV3.java
@@ -39,6 +39,7 @@ import io.gravitee.policy.aws.lambda.configuration.AwsLambdaPolicyConfiguration;
 import io.gravitee.policy.aws.lambda.configuration.PolicyScope;
 import io.gravitee.policy.aws.lambda.el.LambdaResponse;
 import io.gravitee.policy.aws.lambda.invokers.LambdaInvokerV3;
+import io.gravitee.policy.aws.lambda.sdk.AWSCredentialsProviderChain;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import java.util.concurrent.CompletableFuture;
@@ -286,7 +287,7 @@ public class AwsLambdaPolicyV3 {
             // {@see http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html}
             return StaticCredentialsProvider.create(credentials);
         } else {
-            return DefaultCredentialsProvider.create();
+            return AWSCredentialsProviderChain.INSTANCE;
         }
     }
 

--- a/src/main/java/io/gravitee/policy/aws/lambda/sdk/AWSCredentialsProviderChain.java
+++ b/src/main/java/io/gravitee/policy/aws/lambda/sdk/AWSCredentialsProviderChain.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.aws.lambda.sdk;
+
+import software.amazon.awssdk.auth.credentials.*;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class AWSCredentialsProviderChain implements AwsCredentialsProvider {
+
+    private final AwsCredentialsProviderChain instance = AwsCredentialsProviderChain
+        .builder()
+        .credentialsProviders(
+            EnvironmentVariableCredentialsProvider.create(),
+            SystemPropertyCredentialsProvider.create(),
+            ProfileCredentialsProvider.create(),
+            ContainerCredentialsProvider.create(),
+            InstanceProfileCredentialsProvider.builder().asyncCredentialUpdateEnabled(false).build()
+        )
+        .build();
+
+    public static final AWSCredentialsProviderChain INSTANCE = new AWSCredentialsProviderChain();
+
+    @Override
+    public AwsCredentials resolveCredentials() {
+        return instance.resolveCredentials();
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9586

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1-fix-provider-chain-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-aws-lambda/2.0.1-fix-provider-chain-SNAPSHOT/gravitee-policy-aws-lambda-2.0.1-fix-provider-chain-SNAPSHOT.zip)
  <!-- Version placeholder end -->
