### PR TITLE
chore: bump apim version to 4.8.0-alpha.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     </parent>
 
     <properties>
-        <gravitee-apim-bom.version>4.8.0-SNAPSHOT</gravitee-apim-bom.version>
+        <gravitee-apim-bom.version>4.8.0-alpha.1</gravitee-apim-bom.version>
         <gravitee-entrypoint-http-get.version>2.1.0</gravitee-entrypoint-http-get.version>
         <gravitee-reactor-message.version>6.0.1</gravitee-reactor-message.version>
         <aws-java-sdk.version>2.31.26</aws-java-sdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <properties>
         <gravitee-apim-bom.version>4.8.0-alpha.1</gravitee-apim-bom.version>
         <gravitee-entrypoint-http-get.version>2.1.0</gravitee-entrypoint-http-get.version>
-        <gravitee-reactor-message.version>6.0.1</gravitee-reactor-message.version>
+        <gravitee-reactor-message.version>7.0.0-alpha.3</gravitee-reactor-message.version>
         <aws-java-sdk.version>2.31.26</aws-java-sdk.version>
 
         <maven-plugin-assembly.version>3.7.1</maven-plugin-assembly.version>


### PR DESCRIPTION
**Description**

Bump apim to 4.8.0-alpha.1 before releasing alpha branch

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-bump-apim-4-8-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-aws-lambda/3.0.0-bump-apim-4-8-SNAPSHOT/gravitee-policy-aws-lambda-3.0.0-bump-apim-4-8-SNAPSHOT.zip)
  <!-- Version placeholder end -->
