### PR TITLE
feat: enable policy for mcp proxy on request phase

### DIFF
--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -8,3 +8,4 @@ category=others
 icon=aws-lambda.svg
 proxy=REQUEST,RESPONSE
 message=REQUEST,RESPONSE
+mcp_proxy=REQUEST


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13230

**Description**

Enable policy for MCP Proxy APIs on request phase
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.4.0-apim-13230-enable-for-mcp-proxy-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-aws-lambda/3.4.0-apim-13230-enable-for-mcp-proxy-SNAPSHOT/gravitee-policy-aws-lambda-3.4.0-apim-13230-enable-for-mcp-proxy-SNAPSHOT.zip)
  <!-- Version placeholder end -->
