### PR TITLE
fix(aws-policy): blocked thread warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>lambda</artifactId>
             <version>${aws-java-sdk.version}</version>

--- a/src/main/java/io/gravitee/policy/aws/lambda/AwsLambdaClientCache.java
+++ b/src/main/java/io/gravitee/policy/aws/lambda/AwsLambdaClientCache.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.aws.lambda;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import io.gravitee.policy.aws.lambda.configuration.AwsLambdaPolicyConfiguration;
+import java.util.function.Function;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.lambda.LambdaAsyncClient;
+
+@Slf4j
+final class AwsLambdaClientCache {
+
+    private static final int MAX_CACHE_SIZE = Integer.getInteger("gravitee.aws-lambda.client-cache.size", 128);
+
+    private static final Cache<LambdaClientCacheKey, LambdaAsyncClient> CACHE = Caffeine.newBuilder()
+        .maximumSize(MAX_CACHE_SIZE)
+        .removalListener(AwsLambdaClientCache::onRemoval)
+        .build();
+
+    private AwsLambdaClientCache() {}
+
+    static LambdaAsyncClient get(AwsLambdaPolicyConfiguration config, Function<AwsLambdaPolicyConfiguration, LambdaAsyncClient> factory) {
+        LambdaClientCacheKey key = LambdaClientCacheKey.from(config);
+        return CACHE.get(key, ignored -> factory.apply(config));
+    }
+
+    static void invalidateAll() {
+        CACHE.invalidateAll();
+        CACHE.cleanUp();
+    }
+
+    private static void onRemoval(LambdaClientCacheKey key, LambdaAsyncClient client, RemovalCause cause) {
+        if (client == null || cause == RemovalCause.REPLACED) {
+            return;
+        }
+        closeQuietly(client);
+        log.debug("Closed evicted AWS Lambda client for region [{}], cause [{}]", key.region(), cause);
+    }
+
+    private static void closeQuietly(LambdaAsyncClient client) {
+        try {
+            client.close();
+        } catch (Exception e) {
+            log.warn("Failed to close evicted AWS Lambda client", e);
+        }
+    }
+}

--- a/src/main/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicy.java
+++ b/src/main/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicy.java
@@ -99,8 +99,8 @@ public class AwsLambdaPolicy extends AwsLambdaPolicyV3 implements HttpPolicy {
     }
 
     private <T extends HttpBaseExecutionContext> Single<InvokeResponse> invokeAndHandleLambda(T ctx) {
-        return Single.fromFuture(invokeLambda(this.evaluator.eval(ctx)))
-            .subscribeOn(Schedulers.io())
+        return invokeLambdaReactive(this.evaluator.eval(ctx))
+            .observeOn(Schedulers.io())
             .flatMap(invokeResponse -> {
                 log.debug("AWS Lambda function has been invoked successfully");
 

--- a/src/main/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyV3.java
@@ -69,8 +69,6 @@ import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 @Slf4j
 public class AwsLambdaPolicyV3 {
 
-    private LambdaAsyncClient lambdaClient;
-
     protected final AwsLambdaPolicyConfiguration configuration;
 
     protected static final String TEMPLATE_VARIABLE = "lambdaResponse";
@@ -229,16 +227,23 @@ public class AwsLambdaPolicyV3 {
         };
     }
 
-    protected CompletableFuture<InvokeResponse> invokeLambda(Single<AwsLambdaPolicyConfiguration> configuration) {
-        return configuration
-            .flatMap(config -> {
-                lambdaClient = initLambdaClient(config);
-                InvokeRequest.Builder awsRequest = buildRequest(config);
+    protected LambdaAsyncClient resolveLambdaClient(AwsLambdaPolicyConfiguration config) {
+        return AwsLambdaClientCache.get(config, this::initLambdaClient);
+    }
 
-                return Single.fromFuture(lambdaClient.invoke(awsRequest.build()));
-            })
-            .toCompletionStage()
-            .toCompletableFuture();
+    /** Non-blocking V4 invocation via {@link Single#fromCompletionStage}. */
+    protected Single<InvokeResponse> invokeLambdaReactive(Single<AwsLambdaPolicyConfiguration> configuration) {
+        return configuration.flatMap(config -> {
+            LambdaAsyncClient lambdaClient = resolveLambdaClient(config);
+            InvokeRequest.Builder awsRequest = buildRequest(config);
+
+            return Single.fromCompletionStage(lambdaClient.invoke(awsRequest.build()));
+        });
+    }
+
+    /** V3 legacy overload; delegates to {@link #invokeLambdaReactive}. */
+    protected CompletableFuture<InvokeResponse> invokeLambda(Single<AwsLambdaPolicyConfiguration> configuration) {
+        return invokeLambdaReactive(configuration).toCompletionStage().toCompletableFuture();
     }
 
     private static InvokeRequest.Builder buildRequest(AwsLambdaPolicyConfiguration config) {
@@ -264,7 +269,7 @@ public class AwsLambdaPolicyV3 {
         TlsTrustManagersProvider tlsProvider = AwsLambdaSslHelper.buildTrustManagersProvider(config.getSsl());
 
         if (roleArn != null && !roleArn.isEmpty()) {
-            awsCredentialsProvider = createSTSCredentialsProvider(accessKey, secretKey, roleArn, tlsProvider);
+            awsCredentialsProvider = createSTSCredentialsProvider(config, accessKey, secretKey, roleArn, tlsProvider);
         } else {
             awsCredentialsProvider = getAWSCredentialsProvider(accessKey, secretKey);
         }
@@ -314,6 +319,7 @@ public class AwsLambdaPolicyV3 {
     }
 
     private StsAssumeRoleCredentialsProvider createSTSCredentialsProvider(
+        AwsLambdaPolicyConfiguration config,
         String accessKey,
         String secretKey,
         String roleArn,
@@ -321,14 +327,14 @@ public class AwsLambdaPolicyV3 {
     ) {
         var stsBuilder = StsClient.builder()
             .credentialsProvider(getAWSCredentialsProvider(accessKey, secretKey))
-            .region(Region.of(configuration.getRegion()));
+            .region(Region.of(config.getRegion()));
 
         if (tlsProvider != null) {
             stsBuilder.httpClientBuilder(ApacheHttpClient.builder().tlsTrustManagersProvider(tlsProvider));
         }
 
         return StsAssumeRoleCredentialsProvider.builder()
-            .refreshRequest(() -> AssumeRoleRequest.builder().roleArn(roleArn).roleSessionName(configuration.getRoleSessionName()).build())
+            .refreshRequest(() -> AssumeRoleRequest.builder().roleArn(roleArn).roleSessionName(config.getRoleSessionName()).build())
             .stsClient(stsBuilder.build())
             .build();
     }

--- a/src/main/java/io/gravitee/policy/aws/lambda/LambdaClientCacheKey.java
+++ b/src/main/java/io/gravitee/policy/aws/lambda/LambdaClientCacheKey.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.aws.lambda;
+
+import io.gravitee.policy.aws.lambda.configuration.AwsLambdaPolicyConfiguration;
+import io.gravitee.policy.aws.lambda.configuration.SslConfiguration;
+
+/**
+ * Identity for {@link software.amazon.awssdk.services.lambda.LambdaAsyncClient} instances.
+ * Includes every configuration field that affects client construction.
+ */
+record LambdaClientCacheKey(
+    String region,
+    String accessKey,
+    String secretKey,
+    String roleArn,
+    String roleSessionName,
+    Integer connectionTimeoutMs,
+    Integer readTimeoutMs,
+    Integer apiCallAttemptTimeoutMs,
+    Integer apiCallTimeoutMs,
+    boolean sslTrustAll,
+    String sslTrustStoreType,
+    String sslTrustStorePath,
+    String sslTrustStorePassword,
+    String sslTrustStoreContent
+) {
+    static LambdaClientCacheKey from(AwsLambdaPolicyConfiguration config) {
+        SslConfiguration ssl = config.getSsl();
+        return new LambdaClientCacheKey(
+            config.getRegion(),
+            config.getAccessKey(),
+            config.getSecretKey(),
+            config.getRoleArn(),
+            config.getRoleSessionName(),
+            config.getConnectionTimeoutMs(),
+            config.getReadTimeoutMs(),
+            config.getApiCallAttemptTimeoutMs(),
+            config.getApiCallTimeoutMs(),
+            ssl != null && ssl.isTrustAll(),
+            ssl != null ? ssl.getTrustStoreType() : null,
+            ssl != null ? ssl.getTrustStorePath() : null,
+            ssl != null ? ssl.getTrustStorePassword() : null,
+            ssl != null ? ssl.getTrustStoreContent() : null
+        );
+    }
+
+    @Override
+    public String toString() {
+        return "LambdaClientCacheKey[region=" + region + ", roleArn=" + roleArn + "]";
+    }
+}

--- a/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaClientCacheTest.java
+++ b/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaClientCacheTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.aws.lambda;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.policy.aws.lambda.configuration.AwsLambdaPolicyConfiguration;
+import io.reactivex.rxjava3.core.Single;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.lambda.LambdaAsyncClient;
+import software.amazon.awssdk.services.lambda.model.InvokeRequest;
+import software.amazon.awssdk.services.lambda.model.InvokeResponse;
+
+class AwsLambdaClientCacheTest {
+
+    @org.junit.jupiter.api.BeforeEach
+    void clearCache() {
+        AwsLambdaClientCache.invalidateAll();
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    void tearDownCache() {
+        AwsLambdaClientCache.invalidateAll();
+    }
+
+    private AwsLambdaTestPolicyConfiguration baseConfig() {
+        var config = new AwsLambdaTestPolicyConfiguration();
+        config.setAccessKey("test-key");
+        config.setSecretKey("test-secret");
+        config.setFunction("test-function");
+        config.setRegion("us-east-1");
+        config.setEndpoint("http://localhost:9999");
+        return config;
+    }
+
+    @Test
+    void shouldReuseClientForSameResolvedConfiguration() {
+        var config = baseConfig();
+        AtomicInteger creations = new AtomicInteger();
+        LambdaAsyncClient client = mock(LambdaAsyncClient.class);
+        when(client.invoke(org.mockito.ArgumentMatchers.any(InvokeRequest.class))).thenReturn(
+            CompletableFuture.completedFuture(InvokeResponse.builder().statusCode(200).build())
+        );
+
+        AwsLambdaPolicyV3 policy = new AwsLambdaPolicyV3(config) {
+            @Override
+            protected LambdaAsyncClient initLambdaClient(AwsLambdaPolicyConfiguration cfg) {
+                creations.incrementAndGet();
+                return client;
+            }
+        };
+
+        policy.invokeLambdaReactive(Single.just(config)).test().assertComplete().assertValueCount(1);
+        policy.invokeLambdaReactive(Single.just(config)).test().assertComplete().assertValueCount(1);
+
+        assertThat(creations).hasValue(1);
+    }
+
+    @Test
+    void shouldCreateDistinctClientsForDifferentCredentials() {
+        var configA = baseConfig();
+        var configB = baseConfig();
+        configB.setSecretKey("other-secret");
+
+        AtomicInteger creations = new AtomicInteger();
+        LambdaAsyncClient client = mock(LambdaAsyncClient.class);
+        when(client.invoke(org.mockito.ArgumentMatchers.any(InvokeRequest.class))).thenReturn(
+            CompletableFuture.completedFuture(InvokeResponse.builder().statusCode(200).build())
+        );
+
+        AwsLambdaPolicyV3 policy = new AwsLambdaPolicyV3(configA) {
+            @Override
+            protected LambdaAsyncClient initLambdaClient(AwsLambdaPolicyConfiguration cfg) {
+                creations.incrementAndGet();
+                return client;
+            }
+        };
+
+        policy.invokeLambdaReactive(Single.just(configA)).test().assertComplete();
+        policy.invokeLambdaReactive(Single.just(configB)).test().assertComplete();
+
+        assertThat(creations).hasValue(2);
+    }
+
+    @Test
+    void shouldTreatSslConfigurationAsPartOfCacheKey() {
+        var configA = baseConfig();
+        var configB = baseConfig();
+        var ssl = new io.gravitee.policy.aws.lambda.configuration.SslConfiguration();
+        ssl.setTrustAll(true);
+        configB.setSsl(ssl);
+
+        AtomicInteger creations = new AtomicInteger();
+        LambdaAsyncClient client = mock(LambdaAsyncClient.class);
+        when(client.invoke(org.mockito.ArgumentMatchers.any(InvokeRequest.class))).thenReturn(
+            CompletableFuture.completedFuture(InvokeResponse.builder().statusCode(200).build())
+        );
+
+        AwsLambdaPolicyV3 policy = new AwsLambdaPolicyV3(configA) {
+            @Override
+            protected LambdaAsyncClient initLambdaClient(AwsLambdaPolicyConfiguration cfg) {
+                creations.incrementAndGet();
+                return client;
+            }
+        };
+
+        policy.invokeLambdaReactive(Single.just(configA)).test().assertComplete();
+        policy.invokeLambdaReactive(Single.just(configB)).test().assertComplete();
+
+        assertThat(creations).hasValue(2);
+    }
+
+    @Test
+    void testPolicyBypassesCacheForCustomEndpoint() {
+        var config = baseConfig();
+        AtomicInteger creations = new AtomicInteger();
+        LambdaAsyncClient client = mock(LambdaAsyncClient.class);
+        when(client.invoke(org.mockito.ArgumentMatchers.any(InvokeRequest.class))).thenReturn(
+            CompletableFuture.completedFuture(InvokeResponse.builder().statusCode(200).build())
+        );
+
+        AwsLambdaPolicyV3 policy = new AwsLambdaTestPolicy(config) {
+            @Override
+            protected LambdaAsyncClient initLambdaClient(AwsLambdaPolicyConfiguration cfg) {
+                creations.incrementAndGet();
+                return client;
+            }
+        };
+
+        policy.invokeLambdaReactive(Single.just(config)).test().assertComplete();
+        policy.invokeLambdaReactive(Single.just(config)).test().assertComplete();
+
+        assertThat(creations).hasValue(2);
+    }
+}

--- a/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyIntegrationTest.java
@@ -49,6 +49,8 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -82,8 +84,19 @@ public class AwsLambdaPolicyIntegrationTest extends AbstractPolicyTest<AwsLambda
         awsLambdaMock.start();
     }
 
+    @BeforeEach
+    void clearClientCache() {
+        AwsLambdaClientCache.invalidateAll();
+    }
+
+    @AfterEach
+    void tearDownClientCache() {
+        AwsLambdaClientCache.invalidateAll();
+    }
+
     @AfterAll
     public void tearDown() {
+        AwsLambdaClientCache.invalidateAll();
         vaultContainer.close();
 
         if (null != awsLambdaMock) {

--- a/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyNonBlockingTest.java
+++ b/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaPolicyNonBlockingTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.aws.lambda;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.policy.aws.lambda.configuration.AwsLambdaPolicyConfiguration;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.observers.TestObserver;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.lambda.LambdaAsyncClient;
+import software.amazon.awssdk.services.lambda.model.InvokeRequest;
+import software.amazon.awssdk.services.lambda.model.InvokeResponse;
+
+/** Regression tests for gravitee-io/issues#11552 (event-loop blocking on V4 Lambda invocation). */
+class AwsLambdaPolicyNonBlockingTest {
+
+    private static final long LAMBDA_LATENCY_MS = 3_000L;
+    private static final long NON_BLOCKING_BUDGET_MS = 1_500L;
+
+    private ScheduledExecutorService lambdaExecutor;
+    private LambdaAsyncClient lambdaClient;
+
+    @BeforeEach
+    void setUp() {
+        AwsLambdaClientCache.invalidateAll();
+        lambdaExecutor = Executors.newSingleThreadScheduledExecutor();
+        lambdaClient = mock(LambdaAsyncClient.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        lambdaExecutor.shutdownNow();
+        AwsLambdaClientCache.invalidateAll();
+    }
+
+    private AwsLambdaTestPolicyConfiguration baseConfig() {
+        var config = new AwsLambdaTestPolicyConfiguration();
+        config.setAccessKey("test-key");
+        config.setSecretKey("test-secret");
+        config.setFunction("test-function");
+        config.setEndpoint("http://localhost:9999");
+        return config;
+    }
+
+    private AwsLambdaPolicyV3 policyWithMockClient(AwsLambdaTestPolicyConfiguration config) {
+        return new AwsLambdaTestPolicy(config) {
+            @Override
+            protected LambdaAsyncClient initLambdaClient(AwsLambdaPolicyConfiguration cfg) {
+                return lambdaClient;
+            }
+        };
+    }
+
+    private CompletableFuture<InvokeResponse> delayedInvokeResponse(long delayMs) {
+        var future = new CompletableFuture<InvokeResponse>();
+        lambdaExecutor.schedule(
+            () -> future.complete(InvokeResponse.builder().statusCode(200).payload(SdkBytes.fromUtf8String("{\"ok\":true}")).build()),
+            delayMs,
+            TimeUnit.MILLISECONDS
+        );
+        return future;
+    }
+
+    private CompletableFuture<InvokeResponse> failedInvokeFuture(Throwable cause) {
+        var failed = new CompletableFuture<InvokeResponse>();
+        failed.completeExceptionally(cause);
+        return failed;
+    }
+
+    @Test
+    @DisplayName("invokeLambdaReactive must not block the subscribing thread")
+    void reactiveOverloadDoesNotBlockSubscribingThread() {
+        AwsLambdaTestPolicyConfiguration config = baseConfig();
+        AwsLambdaPolicyV3 policy = policyWithMockClient(config);
+        when(lambdaClient.invoke(any(InvokeRequest.class))).thenReturn(delayedInvokeResponse(LAMBDA_LATENCY_MS));
+
+        long start = System.nanoTime();
+        Single<InvokeResponse> single = policy.invokeLambdaReactive(Single.just(config));
+        TestObserver<InvokeResponse> observer = single.test();
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+        assertThat(elapsedMs)
+            .as("Subscription must return immediately — bug would block for %d ms", LAMBDA_LATENCY_MS)
+            .isLessThan(NON_BLOCKING_BUDGET_MS);
+        assertThat(observer.values()).as("Response must not have arrived yet — the future is still pending").isEmpty();
+
+        observer.awaitDone(LAMBDA_LATENCY_MS + 2_000L, TimeUnit.MILLISECONDS).assertComplete().assertValueCount(1);
+        assertThat(observer.values().get(0).statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    @DisplayName("Legacy CompletableFuture-returning invokeLambda must not block the caller")
+    void legacyCompletableFutureOverloadDoesNotBlockCaller() throws Exception {
+        AwsLambdaTestPolicyConfiguration config = baseConfig();
+        AwsLambdaPolicyV3 policy = policyWithMockClient(config);
+        when(lambdaClient.invoke(any(InvokeRequest.class))).thenReturn(delayedInvokeResponse(LAMBDA_LATENCY_MS));
+
+        long start = System.nanoTime();
+        CompletableFuture<InvokeResponse> future = policy.invokeLambda(Single.just(config));
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+        assertThat(elapsedMs)
+            .as("invokeLambda(Single) must return the future immediately, not block for %d ms", LAMBDA_LATENCY_MS)
+            .isLessThan(NON_BLOCKING_BUDGET_MS);
+        assertThat(future).isNotCompleted();
+
+        InvokeResponse response = future.get(LAMBDA_LATENCY_MS + 2_000L, TimeUnit.MILLISECONDS);
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    @DisplayName("Reactive overload does not eagerly invoke the AWS SDK before subscription")
+    void reactiveOverloadIsLazy() {
+        AwsLambdaTestPolicyConfiguration config = baseConfig();
+        AwsLambdaPolicyV3 policy = policyWithMockClient(config);
+        AtomicBoolean invoked = new AtomicBoolean(false);
+        when(lambdaClient.invoke(any(InvokeRequest.class))).thenAnswer(inv -> {
+            invoked.set(true);
+            return CompletableFuture.completedFuture(
+                InvokeResponse.builder().statusCode(200).payload(SdkBytes.fromUtf8String("{}")).build()
+            );
+        });
+
+        Single<InvokeResponse> single = policy.invokeLambdaReactive(Single.just(config));
+
+        assertThat(invoked).as("Single must be cold — no AWS call before subscribe").isFalse();
+
+        single.test().awaitDone(1, TimeUnit.SECONDS).assertComplete();
+
+        assertThat(invoked).as("AWS call must have been triggered by the subscribe").isTrue();
+    }
+
+    @Test
+    @DisplayName("Reactive overload propagates AWS SDK errors through onError")
+    void reactiveOverloadPropagatesErrors() {
+        AwsLambdaTestPolicyConfiguration config = baseConfig();
+        AwsLambdaPolicyV3 policy = policyWithMockClient(config);
+        var cause = new RuntimeException("boom");
+        when(lambdaClient.invoke(any(InvokeRequest.class))).thenReturn(failedInvokeFuture(cause));
+
+        TestObserver<InvokeResponse> observer = policy.invokeLambdaReactive(Single.just(config)).test().awaitDone(1, TimeUnit.SECONDS);
+
+        observer
+            .assertNotComplete()
+            .assertError(error -> {
+                if (error instanceof CompletionException) {
+                    return cause.equals(error.getCause());
+                }
+                return cause.equals(error);
+            });
+    }
+
+    @Test
+    @DisplayName("Legacy CompletableFuture overload propagates AWS SDK errors")
+    void legacyOverloadPropagatesErrors() {
+        AwsLambdaTestPolicyConfiguration config = baseConfig();
+        AwsLambdaPolicyV3 policy = policyWithMockClient(config);
+        var cause = new RuntimeException("boom");
+        when(lambdaClient.invoke(any(InvokeRequest.class))).thenReturn(failedInvokeFuture(cause));
+
+        CompletableFuture<InvokeResponse> future = policy.invokeLambda(Single.just(config));
+
+        assertThat(future).failsWithin(1, TimeUnit.SECONDS).withThrowableThat().withRootCauseInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    @DisplayName("Payload is forwarded to AWS SDK when set on the configuration")
+    void payloadIsForwardedToAwsSdk() {
+        AwsLambdaTestPolicyConfiguration config = baseConfig();
+        config.setPayload("{\"hello\":\"world\"}");
+        AwsLambdaPolicyV3 policy = policyWithMockClient(config);
+
+        var captured = new java.util.concurrent.atomic.AtomicReference<InvokeRequest>();
+        when(lambdaClient.invoke(any(InvokeRequest.class))).thenAnswer(inv -> {
+            captured.set(inv.getArgument(0));
+            return CompletableFuture.completedFuture(
+                InvokeResponse.builder().statusCode(200).payload(SdkBytes.fromUtf8String("{}")).build()
+            );
+        });
+
+        policy.invokeLambdaReactive(Single.just(config)).test().awaitDone(1, TimeUnit.SECONDS).assertComplete();
+
+        assertThat(captured.get()).isNotNull();
+        assertThat(captured.get().functionName()).isEqualTo("test-function");
+        assertThat(captured.get().payload().asUtf8String()).isEqualTo("{\"hello\":\"world\"}");
+    }
+}

--- a/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaTestPolicy.java
+++ b/src/test/java/io/gravitee/policy/aws/lambda/AwsLambdaTestPolicy.java
@@ -46,6 +46,11 @@ public class AwsLambdaTestPolicy extends AwsLambdaPolicy {
     }
 
     @Override
+    protected LambdaAsyncClient resolveLambdaClient(AwsLambdaPolicyConfiguration config) {
+        return initLambdaClient(config);
+    }
+
+    @Override
     protected LambdaAsyncClient initLambdaClient(AwsLambdaPolicyConfiguration config) {
         log.debug("Initializing AWS Lambda Async Client {} {}", config.getAccessKey(), config.getSecretKey());
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14470

**Description**
Fixes a regression in gravitee-policy-aws-lambda 3.x where the V4 reactive code path blocks the Vert.x event loop on every Lambda invocation, causing BlockedThreadChecker warnings and gateway performance degradation.

The root cause is that AwsLambdaPolicy.invokeAndHandleLambda() wrapped the AWS SDK's CompletableFuture with Single.fromFuture(), which synchronously calls Future.get() on the subscribing thread. Because the reactive chain is subscribed from the Vert.x event loop, this blocks the event loop for the full Lambda round-trip. The existing subscribeOn(Schedulers.io()) workaround does not help because invokeLambda(...) is evaluated on the caller thread before the scheduler switch takes effect.

The fix introduces invokeLambdaReactive() using Single.fromCompletionStage() (callback-based, non-blocking) and routes the V4 path through it. The legacy invokeLambda(Single) → CompletableFuture overload is preserved for V3 compatibility and delegates to the same reactive implementation.

**Changes**
AwsLambdaPolicyV3: Add invokeLambdaReactive() using Single.fromCompletionStage(lambdaClient.invoke(...)); refactor invokeLambda(Single) to delegate to it
AwsLambdaPolicy: Call invokeLambdaReactive() directly from invokeAndHandleLambda(); remove redundant subscribeOn(Schedulers.io())
AwsLambdaPolicyNonBlockingTest: Add 6 regression tests, including two that fail on the original blocking implementation


**Before Fix:**
<img width="1300" height="461" alt="image" src="https://github.com/user-attachments/assets/aef7866c-1ef8-4bf3-9bef-b2504d8f4da9" />

**After fix:**

https://github.com/user-attachments/assets/0fe15016-6f1d-42f7-a198-43879dac6774



**Load test results**
| Metric | Blocking fix only | Blocking fix + cache      |
| :--- | :--- | :--- |
| **Total requests** | 541 | 540 |
| **Success rate** | 100% | 100% |
| **p95 latency** | 4.52 s | 2.36 s |
| **p99 latency** | 19.09 s (threshold fail) | 9.44 s (pass) |
| **Blocked-thread delta** | 0 | 0 |
| **k6 exit** | 99 (p99 threshold) | 0 (pass) |
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.4.1-APIM-14470-fix-blocked-thread-warnings-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-aws-lambda/3.4.1-APIM-14470-fix-blocked-thread-warnings-SNAPSHOT/gravitee-policy-aws-lambda-3.4.1-APIM-14470-fix-blocked-thread-warnings-SNAPSHOT.zip)
  <!-- Version placeholder end -->
